### PR TITLE
Replace gilsonurbano references

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,6 @@ type: software
 authors:
   - family-names: Urbano
     given-names: Gilson
-    email: hello@gilsonurbano.com
+    email: ricardomalnati@gmail.com
 url: 'https://github.com/urbanogilson/SICAR'
 license: MIT

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ O notebook permite baixar os shapefiles diretamente no navegador sem instalar na
 
 ## 4️⃣ Execução via API
 
-Uma API pública de demonstração está disponível em [gilsonurbano.com/sicar-api](https://gilsonurbano.com/sicar-api/). O endpoint `/download` aceita requisições `POST` contendo o estado e o tipo de polígono desejado.
+Uma API pública de demonstração está disponível em [GitHub.com/Malnati/sicar-api](https://GitHub.com/Malnati/sicar-api/). O endpoint `/download` aceita requisições `POST` contendo o estado e o tipo de polígono desejado.
 
 ### Campos esperados (multipart/form)
 
@@ -120,7 +120,7 @@ Uma API pública de demonstração está disponível em [gilsonurbano.com/sicar-
 ### Exemplo via curl
 
 ```bash
-curl -X POST https://gilsonurbano.com/sicar-api/download \
+curl -X POST https://GitHub.com/Malnati/sicar-api/download \
   -F "state=SP" \
   -F "polygon=APPS" \
   --output SP_APPS.zip

--- a/SICAR/tests/unit/exceptions.py
+++ b/SICAR/tests/unit/exceptions.py
@@ -11,7 +11,7 @@ from SICAR.exceptions import (
 
 class ExceptionTestCase(unittest.TestCase):
     def test_url_not_ok_exception(self):
-        url = "https://gilsonurbano.com"
+        url = "https://GitHub.com/Malnati"
         with self.assertRaises(UrlNotOkException) as context:
             raise UrlNotOkException(url)
         self.assertEqual(str(context.exception), f"Oh no! Failed to access {url}!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "SICAR"
 version = "0.7.7"
-authors = [{ name = "Gilson Urbano", email = "hello@gilsonurbano.com" }]
+authors = [{ name = "Gilson Urbano", email = "ricardomalnati@gmail.com" }]
 description = "SICAR - Tool designed for students, researchers, data scientists or anyone who would like to have access to SICAR files."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- update contact info and website references

## Testing
- `python -m unittest SICAR/tests/unit/*.py SICAR/tests/unit/drivers/*.py` *(fails: ModuleNotFoundError: No module named 'SICAR')*
- `pip install paddlepaddle paddleocr` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68631d673fcc832fb9c7c44d8b3aec76