### PR TITLE
Add tries parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ ambiente e a execução do exemplo `download_state.py`. Basta informar os
 parâmetros desejados:
 
 ```bash
-./download_state.sh --state DF --polygon APPS --folder data/DF --debug True
+./download_state.sh --state DF --polygon APPS --folder data/DF --tries 25 --debug True
 ```
 
 O script irá garantir que a versão correta do Python esteja disponível via

--- a/SICAR/sicar.py
+++ b/SICAR/sicar.py
@@ -39,6 +39,8 @@ from SICAR.exceptions import (
     FailedToGetReleaseDateException,
 )
 
+DEFAULT_TIMEOUT = 30
+
 
 class Sicar(Url):
     """

--- a/SICAR/tests/unit/sicar.py
+++ b/SICAR/tests/unit/sicar.py
@@ -10,6 +10,7 @@ import sys
 import ssl
 
 from SICAR import Sicar
+from SICAR.sicar import DEFAULT_TIMEOUT
 from SICAR.state import State
 from SICAR.polygon import Polygon
 from SICAR.drivers import Captcha

--- a/download_state.sh
+++ b/download_state.sh
@@ -4,7 +4,7 @@
 set -e
 
 # \U1F9E0 Uso:
-# ./download_state.sh --state DF --polygon APPS --folder data/DF --debug True
+# ./download_state.sh --state DF --polygon APPS --folder data/DF --tries 25 --debug True
 
 # \U1F9EA Verifica pyenv
 if ! command -v pyenv &> /dev/null; then
@@ -52,9 +52,13 @@ while [[ "$#" -gt 0 ]]; do
       DEBUG="$2"
       shift 2
       ;;
+    --tries)
+      TRIES="$2"
+      shift 2
+      ;;
     *)
       echo "Erro: Parâmetro desconhecido $1"
-      echo "Uso: ./download_state.sh --state <state> --polygon <polygon> --folder <folder> --debug <debug>"
+      echo "Uso: ./download_state.sh --state <state> --polygon <polygon> --folder <folder> --tries <tries> --debug <debug>"
       exit 1
       ;;
   esac
@@ -63,13 +67,13 @@ done
 # Verifica se os parâmetros obrigatórios foram passados
 if [ -z "$STATE" ] || [ -z "$POLYGON" ] || [ -z "$FOLDER" ]; then
   echo "Erro: Parâmetros obrigatórios faltando."
-  echo "Uso: ./download_state.sh --state <state> --polygon <polygon> --folder <folder> --debug <debug>"
+  echo "Uso: ./download_state.sh --state <state> --polygon <polygon> --folder <folder> --tries <tries> --debug <debug>"
   exit 1
 fi
 
 # \U1F4D1 Exemplo de parâmetros passados para o script
-echo "Executando download para o estado $STATE, polígono $POLYGON, na pasta $FOLDER com debug=$DEBUG..."
+echo "Executando download para o estado $STATE, polígono $POLYGON, na pasta $FOLDER com tries=$TRIES e debug=$DEBUG..."
 
 # \u25B6️ Executa o script download_state.py com os parâmetros fornecidos
-python examples/download_state.py --state "$STATE" --polygon "$POLYGON" --folder "$FOLDER" --debug "$DEBUG"
+python examples/download_state.py --state "$STATE" --polygon "$POLYGON" --folder "$FOLDER" --tries "$TRIES" --debug "$DEBUG"
 

--- a/examples/download_state.py
+++ b/examples/download_state.py
@@ -10,13 +10,16 @@ state = State[os.getenv("STATE", "DF")]
 polygon = Polygon[os.getenv("POLYGON", "APPS")]
 folder = os.getenv("FOLDER", "data/DF")
 debug = os.getenv("DEBUG", "False").lower() == "true"
+tries = int(os.getenv("TRIES", "25"))
 
 # Create Sicar instance (default driver is Tesseract)
 car = Sicar(driver=Tesseract)
 # car = Sicar(driver=Paddle)
 
 # Download polygons for the chosen state
-car.download_state(state=state, polygon=polygon, folder=folder, debug=debug)
+car.download_state(
+    state=state, polygon=polygon, folder=folder, tries=tries, debug=debug
+)
 
 # Get release date for all states and print the one for the chosen state
 release_dates = car.get_release_dates()


### PR DESCRIPTION
## Summary
- add tries env var to download_state example
- support --tries in helper shell script
- document new tries argument in README
- define DEFAULT_TIMEOUT constant
- import DEFAULT_TIMEOUT in tests

## Testing
- `pip install .`
- `pip install paddleocr paddlepaddle`
- `make test` *(fails: FileNotFoundError for tesseract)*

------
https://chatgpt.com/codex/tasks/task_e_6863d4d75d40832fbbea24de10bd8e71