### PR TITLE
Add FastAPI API for SICAR downloads

### DIFF
--- a/api.sh
+++ b/api.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # api.sh
 
 set -e

--- a/api.sh
+++ b/api.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# api.sh
+
+set -e
+
+VENV=".venv-api"
+PYTHON_VERSION="3.11.8"
+
+if ! command -v pyenv &> /dev/null; then
+  echo "❌ pyenv não encontrado. Instale antes de continuar."
+  exit 1
+fi
+
+if [ ! -d "$VENV" ]; then
+  echo "⚙️ Criando ambiente virtual $VENV"
+  pyenv install -s $PYTHON_VERSION
+  pyenv exec python -m venv $VENV
+fi
+
+source $VENV/bin/activate
+
+pip install --upgrade pip
+pip install fastapi uvicorn httpx Pillow tqdm
+
+echo "🚀 Servidor FastAPI pronto em http://localhost:8000"
+uvicorn app:app --reload --port 8000

--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ def extract_and_find_shp(upload_file: UploadFile, temp_dir: str) -> str:
 async def download_state_endpoint(
     state: str = Form(...),
     polygon: str = Form(...),
-    folder: str = Form("temp"),
+    folder: str = Form(None),
     tries: int = Form(25),
     debug: bool = Form(False),
     timeout: int = Form(30),

--- a/app.py
+++ b/app.py
@@ -1,0 +1,106 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import StreamingResponse
+import tempfile
+import shutil
+import os
+import zipfile
+from pathlib import Path
+
+from SICAR import Sicar, State, Polygon
+from SICAR.drivers import Tesseract
+
+app = FastAPI()
+
+
+def zip_shapefile(shp_path: str) -> str:
+    base = os.path.splitext(shp_path)[0]
+    exts = [".shp", ".shx", ".dbf", ".prj"]
+    files = [base + ext for ext in exts if os.path.exists(base + ext)]
+    zip_path = base + ".zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        for f in files:
+            zipf.write(f, arcname=os.path.basename(f))
+    return zip_path
+
+
+def extract_and_find_shp(upload_file: UploadFile, temp_dir: str) -> str:
+    zip_path = os.path.join(temp_dir, upload_file.filename)
+    with open(zip_path, "wb") as f:
+        shutil.copyfileobj(upload_file.file, f)
+
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        zip_ref.extractall(temp_dir)
+
+    shp_path = None
+    for root, _dirs, files in os.walk(temp_dir):
+        for file in files:
+            if file.lower().endswith(".shp"):
+                shp_path = os.path.join(root, file)
+    if shp_path:
+        return shp_path
+    raise ValueError(f"No .shp file found in zip '{upload_file.filename}'.")
+
+
+@app.post("/download_state")
+async def download_state_endpoint(
+    state: str = Form(...),
+    polygon: str = Form(...),
+    folder: str = Form("temp"),
+    tries: int = Form(25),
+    debug: bool = Form(False),
+    timeout: int = Form(30),
+):
+    try:
+        car = Sicar(driver=Tesseract)
+        path = car.download_state(
+            state=State[state.upper()],
+            polygon=Polygon[polygon.upper()],
+            folder=folder,
+            tries=tries,
+            debug=debug,
+            timeout=timeout,
+        )
+        zip_path = zip_shapefile(str(path))
+        zip_file_handle = open(zip_path, "rb")
+        return StreamingResponse(
+            zip_file_handle,
+            media_type="application/zip",
+            headers={"Content-Disposition": f'attachment; filename="{state}_{polygon}.zip"'},
+        )
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+@app.post("/download_country")
+async def download_country_endpoint(
+    polygon: str = Form(...),
+    folder: str = Form("brazil"),
+    tries: int = Form(25),
+    debug: bool = Form(False),
+    timeout: int = Form(30),
+):
+    try:
+        car = Sicar(driver=Tesseract)
+        result = car.download_country(
+            polygon=Polygon[polygon.upper()],
+            folder=folder,
+            tries=tries,
+            debug=debug,
+            timeout=timeout,
+        )
+        zip_paths = []
+        for _state, path in result.items():
+            zip_paths.append(zip_shapefile(str(path)))
+        with tempfile.NamedTemporaryFile(delete=False) as zip_file:
+            with zipfile.ZipFile(zip_file, "w", zipfile.ZIP_DEFLATED) as zipf:
+                for z in zip_paths:
+                    zipf.write(z, os.path.basename(z))
+            zip_file_path = zip_file.name
+        zip_file_handle = open(zip_file_path, "rb")
+        return StreamingResponse(
+            zip_file_handle,
+            media_type="application/zip",
+            headers={"Content-Disposition": f'attachment; filename="brazil_{polygon}.zip"'},
+        )
+    except Exception as exc:
+        return {"error": str(exc)}


### PR DESCRIPTION
## Summary
- implement `app.py` with FastAPI endpoints `/download_state` and `/download_country`
- provide helper shell script `api.sh` for running the API

## Testing
- `make unit-test`
- `make test` *(fails: SSL handshake to consultapublica.car.gov.br and missing Tesseract)*

------
https://chatgpt.com/codex/tasks/task_e_6863dbe80224832f955ba0ea2a3aa623