### PR TITLE
Update Docker Compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,27 +97,28 @@ ambiente apropriadas.
 
 ## 3️⃣ Execução via Docker Compose
 
-Crie um arquivo `docker-compose.yml` simples apontando para este repositório:
+O repositório já possui um `docker-compose.yml` configurado com dois serviços:
 
-```yaml
-version: "3.8"
-services:
-  sicar:
-    build: .
-    volumes:
-      - .:/sicar
-    command: python examples/docker.py
-```
+* **download** – roda o script `entrypoint.download.sh` para baixar os arquivos
+  desejados. Defina as variáveis `STATE`, `POLYGON` e `FOLDER` conforme a
+  necessidade.
+* **api** – executa o `uvicorn` servindo a aplicação FastAPI em
+  `http://localhost:8000`.
+
+Primeiro, construa a imagem base:
 
 ```bash
-pip install 'SICAR[paddle] @  git+https://github.com/Malnati/download-car'
+make build
 ```
 
-Execute:
+Em seguida, suba os serviços:
 
 ```bash
-docker compose up --build
+docker compose up
 ```
+
+Os logs do container de download indicarão o progresso do script, enquanto o
+serviço da API ficará disponível na porta `8000` para testes locais.
 
 ## 4️⃣ Execução via Google Colab (Notebook Interativo)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  download:
+    build: .
+    entrypoint: ./entrypoint.download.sh
+    volumes:
+      - .:/sicar
+  api:
+    build: .
+    command: uvicorn app:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/sicar

--- a/entrypoint.download.sh
+++ b/entrypoint.download.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+set -e
+
+STATE=${STATE:-DF}
+POLYGON=${POLYGON:-APPS}
+FOLDER=${FOLDER:-data/$STATE}
+TRIES=${TRIES:-25}
+DEBUG=${DEBUG:-False}
+TIMEOUT=${TIMEOUT:-30}
+MAX_RETRIES=${MAX_RETRIES:-5}
+
+python examples/download_state.py \
+  --state "$STATE" \
+  --polygon "$POLYGON" \
+  --folder "$FOLDER" \
+  --tries "$TRIES" \
+  --debug "$DEBUG" \
+  --timeout "$TIMEOUT" \
+  --max_retries "$MAX_RETRIES"

--- a/entrypoint.download.sh
+++ b/entrypoint.download.sh
@@ -9,6 +9,7 @@ DEBUG=${DEBUG:-False}
 TIMEOUT=${TIMEOUT:-30}
 MAX_RETRIES=${MAX_RETRIES:-5}
 
+mkdir -p "$FOLDER"
 python examples/download_state.py \
   --state "$STATE" \
   --polygon "$POLYGON" \


### PR DESCRIPTION
## Summary
- add docker-compose.yml and entrypoint script for downloads
- update README Docker Compose section to reference the new file and usage

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6863e8062e74832fb438be02c7a81e2d