### PR TITLE
Add Docker build setup with entrypoints

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+__pycache__
+.venv*
+tests
+

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,18 @@
+# Dockerfile.api
+FROM download-car-base:latest
+
+ENV CPLUS_INCLUDE_PATH=/usr/include/gdal \
+    C_INCLUDE_PATH=/usr/include/gdal
+
+WORKDIR /app
+COPY app.py ./
+
+COPY entrypoint.api.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV PYENV_ROOT=/opt/pyenv
+ENV PATH=/opt/pyenv/shims:/opt/pyenv/bin:$PATH
+
+EXPOSE 8000
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,21 @@
+# Dockerfile.base
+FROM ubuntu:22.04
+
+ARG PYTHON_VERSION=3.11.9
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYENV_ROOT=/opt/pyenv \
+    PATH="/opt/pyenv/bin:/opt/pyenv/shims:${PATH}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential curl git ca-certificates \
+        libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+        libffi-dev liblzma-dev libncursesw5-dev xz-utils tk-dev libgdbm-dev \
+        uuid-dev wget && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
+    pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION}
+
+RUN pip install --no-cache-dir --upgrade pip
+

--- a/Dockerfile.download-car
+++ b/Dockerfile.download-car
@@ -1,0 +1,16 @@
+# Dockerfile.download-car
+FROM download-car-base:latest
+
+ENV CPLUS_INCLUDE_PATH=/usr/include/gdal \
+    C_INCLUDE_PATH=/usr/include/gdal
+
+WORKDIR /app
+COPY . .
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir --editable .[paddle]
+
+COPY entrypoint.download.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.api.sh
+++ b/entrypoint.api.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# entrypoint.api.sh
+set -e
+
+VENV=/opt/venv
+PYTHON=python
+
+${PYTHON} -m venv $VENV
+source $VENV/bin/activate
+
+pip install --upgrade pip
+pip install fastapi uvicorn httpx Pillow tqdm
+
+exec uvicorn app:app --host 0.0.0.0 --port 8000

--- a/entrypoint.download.sh
+++ b/entrypoint.download.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# entrypoint.download.sh
+set -e
+
+STATE=${STATE:-DF}
+POLYGON=${POLYGON:-APPS}
+FOLDER=${FOLDER:-data/DF}
+TRIES=${TRIES:-25}
+DEBUG=${DEBUG:-False}
+TIMEOUT=${TIMEOUT:-30}
+MAX_RETRIES=${MAX_RETRIES:-5}
+
+exec python examples/download_state.py \
+    --state "$STATE" \
+    --polygon "$POLYGON" \
+    --folder "$FOLDER" \
+    --tries "$TRIES" \
+    --debug "$DEBUG" \
+    --timeout "$TIMEOUT" \
+    --max_retries "$MAX_RETRIES"


### PR DESCRIPTION
## Summary
- provide a reusable base Dockerfile with pyenv Python 3.11.9
- add Dockerfiles for package download usage and API server
- include entrypoint scripts for download and API containers
- ignore temporary files when building images

## Testing
- `pip install -e .[paddle,dev]`
- `make test` *(fails: Calls not found; expected call not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e7f9c40c832f98a61432d375547c