### PR TITLE
Fix package install name

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -28,7 +28,7 @@ RUN pip install 'download_car[paddle]@git+https://github.com/Malnati/download-ca
 
 WORKDIR /download-car
 
-RUN pip install 'SICAR[paddle]@git+https://github.com/Malnati/download-car'
+RUN pip install download-car
 
 # Download PaddleOCR models
 RUN echo 'from paddleocr import PaddleOCR\nPaddleOCR(lang="en")' | python


### PR DESCRIPTION
## Summary
- fix incorrect package name in Dockerfile.base

## Testing
- `pip install -e .[dev]`
- `make test` *(fails: ImportError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6865d8928ff8832fa15c1af6889e7928