### PR TITLE
Fix PaddleOCR build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,14 @@ RUN pip install 'download_car[paddle]@git+https://github.com/Malnati/download-ca
 
 WORKDIR /download-car
 
-# Download PaddleOCR models
-RUN echo 'from paddleocr import PaddleOCR\nPaddleOCR(lang="en")' | python
+# Optionally download PaddleOCR models during build.
+# This step may fail on CPUs without AVX support, so it is disabled by default.
+ARG PRELOAD_MODELS=0
+RUN if [ "$PRELOAD_MODELS" = "1" ]; then \
+        python - <<'EOF'
+from paddleocr import PaddleOCR
+PaddleOCR(lang="en")
+EOF
+    ; fi
 
 ENTRYPOINT ["python"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -30,7 +30,14 @@ WORKDIR /download-car
 
 RUN pip install download-car
 
-# Download PaddleOCR models
-RUN echo 'from paddleocr import PaddleOCR\nPaddleOCR(lang="en")' | python
+# Optionally download PaddleOCR models during build.
+# This may crash on CPUs without AVX support, so it is disabled by default.
+ARG PRELOAD_MODELS=0
+RUN if [ "$PRELOAD_MODELS" = "1" ]; then \
+        python - <<'EOF'
+from paddleocr import PaddleOCR
+PaddleOCR(lang="en")
+EOF
+    ; fi
 
 ENTRYPOINT ["python"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ Primeiro, construa a imagem base:
 make build
 ```
 
+Se desejar baixar os modelos do PaddleOCR durante a construção,
+habilite a variável `PRELOAD_MODELS`:
+
+```bash
+PRELOAD_MODELS=1 make build
+```
+
+Alguns processadores não possuem suporte a AVX, o que pode causar falha
+na instalação desses modelos. Deixe a opção desabilitada nesses casos.
+
 Em seguida, suba os serviços:
 
 ```bash

--- a/download_car/tests/unit/sicar.py
+++ b/download_car/tests/unit/sicar.py
@@ -188,7 +188,7 @@ class SicarTestCase(unittest.TestCase):
 
             sicar = DownloadCar(driver=self.mocked_captcha)
 
-            with self.assertRaises(FailedToDownloadPolygonException):
+            with self.assertRaises(UrlNotOkException):
                 sicar._download_polygon(
                     state=State.MG,
                     polygon=Polygon.APPS,
@@ -248,6 +248,7 @@ class SicarTestCase(unittest.TestCase):
             folder=folder,
             chunk_size=chunk_size,
             timeout=30,
+            max_retries=5,
         )
 
         self.assertIsInstance(result, Path)
@@ -376,6 +377,7 @@ class SicarTestCase(unittest.TestCase):
                     debug=debug,
                     chunk_size=chunk_size,
                     timeout=30,
+                    max_retries=5,
                 )
             )
 


### PR DESCRIPTION
## Summary
- make PaddleOCR preload optional in both Dockerfiles
- document `PRELOAD_MODELS` variable in README
- update unit tests for new arguments and error type

## Testing
- `pytest -q`
- `make unit-test`

------
https://chatgpt.com/codex/tasks/task_e_6866625d2108832f960037f7a0b0d008