### PR TITLE
Fix API form handling

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -6,7 +6,7 @@ WORKDIR /download-car
 
 COPY app.py /download-car/
 
-RUN pip install fastapi uvicorn httpx Pillow tqdm
+RUN pip install fastapi uvicorn httpx Pillow tqdm python-multipart
 
 ENTRYPOINT ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
 


### PR DESCRIPTION
## Summary
- add `python-multipart` in `Dockerfile.api` to support FastAPI forms

## Testing
- `make test` *(fails: tesseract not installed and connection issues)*

------
https://chatgpt.com/codex/tasks/task_e_686670435364832f9ca26bf0e9d0f034