### PR TITLE
Fix entrypoint install

### DIFF
--- a/entrypoint.api.sh
+++ b/entrypoint.api.sh
@@ -9,6 +9,6 @@ ${PYTHON} -m venv $VENV
 source $VENV/bin/activate
 
 pip install --upgrade pip
-pip install fastapi uvicorn httpx Pillow tqdm
+pip install fastapi uvicorn httpx Pillow tqdm python-multipart
 
 exec uvicorn app:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- include python-multipart in API entrypoint dependencies

## Testing
- `make test` *(fails: httpx ConnectError in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68667375c2a4832f928db475803867c6