### PR TITLE
Fix Makefile build-api duplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,6 @@ build-download:
 	@echo "🛠️  Building download image..."
 	docker build -t download-car-download:latest -f Dockerfile.download-car .
 
-build-api:
-	@echo "🛠️  Building api image..."
-	docker build -t download-car-api:latest -f Dockerfile.api .
-
 build: build-base build-download build-api
 
 up:


### PR DESCRIPTION
## Summary
- remove second `build-api` rule from Makefile

## Testing
- `pip install -e .`
- `pip install paddlepaddle paddleocr`
- `make test` *(fails: tesseract not installed and network issues during integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_686673817660832f8f86fa75535bfea1