### PR TITLE
Fix sicar integration test import

### DIFF
--- a/download_car/tests/integration/sicar.py
+++ b/download_car/tests/integration/sicar.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import unittest
 from unittest.mock import patch
+import tempfile
 
 from download_car import DownloadCar, State, Polygon
 


### PR DESCRIPTION
## Summary
- import tempfile for integration test

## Testing
- `make unit-test`
- `make integration-test` *(fails: tesseract missing, SSL handshake failures)*

------
https://chatgpt.com/codex/tasks/task_e_686673b92b6c832f9b41841bc3903983