### PR TITLE
Fix download_country return

### DIFF
--- a/download_car/sicar.py
+++ b/download_car/sicar.py
@@ -412,6 +412,8 @@ class DownloadCar(Url):
                 max_retries=max_retries,
             )
 
+        return result
+
     def get_release_dates(self) -> Dict:
         """
         Get release date for each state in download-car system.

--- a/download_car/tests/unit/sicar.py
+++ b/download_car/tests/unit/sicar.py
@@ -363,7 +363,7 @@ class SicarTestCase(unittest.TestCase):
             "State2": Path("/path/to/456.zip"),
         }
 
-        sicar.download_country(polygon, folder, tries, debug, chunk_size)
+        result = sicar.download_country(polygon, folder, tries, debug, chunk_size)
 
         expected_calls = {"path": [], "download_state": []}
         for state in State:
@@ -383,6 +383,9 @@ class SicarTestCase(unittest.TestCase):
 
         mock_mkdir.assert_has_calls(expected_calls["path"])
         mock_download_state.assert_has_calls(expected_calls["download_state"])
+
+        expected_result = {str(state): mock_download_state.return_value for state in State}
+        self.assertEqual(result, expected_result)
 
     def test_get_release_dates_success(self):
         html_content = (


### PR DESCRIPTION
## Summary
- return result dict from `DownloadCar.download_country`
- check returned value in unit tests

## Testing
- `pytest download_car/tests/unit/sicar.py::SicarTestCase::test_download_country -q`

------
https://chatgpt.com/codex/tasks/task_e_686673d5d9bc832fa2905be11bbe2a5e