### PR TITLE
Use Pyenv in shell scripts

### DIFF
--- a/api.sh
+++ b/api.sh
@@ -3,7 +3,6 @@
 
 set -e
 
-VENV=".venv-api"
 PYTHON_VERSION="3.11.8"
 
 if ! command -v pyenv &> /dev/null; then
@@ -11,16 +10,10 @@ if ! command -v pyenv &> /dev/null; then
   exit 1
 fi
 
-if [ ! -d "$VENV" ]; then
-  echo "⚙️ Criando ambiente virtual $VENV"
-  pyenv install -s $PYTHON_VERSION
-  pyenv exec python -m venv $VENV
-fi
-
-source $VENV/bin/activate
-
-pip install --upgrade pip
-pip install fastapi uvicorn httpx Pillow tqdm
+pyenv install -s "$PYTHON_VERSION"
+PYENV_VERSION="$PYTHON_VERSION" pyenv exec pip install --upgrade pip
+PYENV_VERSION="$PYTHON_VERSION" pyenv exec pip install fastapi uvicorn httpx Pillow tqdm
 
 echo "🚀 Servidor FastAPI pronto em http://localhost:8000"
-uvicorn app:app --reload --port 8000
+PYENV_VERSION="$PYTHON_VERSION" pyenv exec uvicorn app:app --reload --port 8000
+

--- a/download_state.sh
+++ b/download_state.sh
@@ -19,19 +19,10 @@ if ! pyenv versions --bare | grep -q "^$PYTHON_VERSION$"; then
   pyenv install $PYTHON_VERSION
 fi
 
-# \U1F4E6 Cria venv se não existir
-VENV_DIR=".venv-download"
-if [[ ! -d "$VENV_DIR" ]]; then
-  echo -e "\u23f3 Criando venv Python em $VENV_DIR..."
-  PYENV_VERSION=$PYTHON_VERSION pyenv exec python -m venv $VENV_DIR
-fi
-
-# \u26A1 Ativa venv
-source $VENV_DIR/bin/activate
-
-# \u1F680 Instala dependências
-pip install --upgrade pip
-pip install --editable .[paddle]
+# \u1F680 Instala dependências via pyenv
+pyenv install -s "$PYTHON_VERSION"
+PYENV_VERSION="$PYTHON_VERSION" pyenv exec pip install --upgrade pip
+PYENV_VERSION="$PYTHON_VERSION" pyenv exec pip install --editable .[paddle]
 
 # \u1F6E0 Define variáveis de ambiente para passar os parâmetros para o script Python
 while [[ "$#" -gt 0 ]]; do
@@ -88,5 +79,12 @@ DEBUG="${DEBUG:-False}"
 echo "Executando download para o estado $STATE, polígono $POLYGON, na pasta $FOLDER com tries=$TRIES, debug=$DEBUG, timeout=$TIMEOUT e max_retries=$MAX_RETRIES..."
 
 # \u25B6️ Executa o script download_state.py com os parâmetros fornecidos
-python examples/download_state.py --state "$STATE" --polygon "$POLYGON" --folder "$FOLDER" --tries "$TRIES" --debug "$DEBUG" --timeout "$TIMEOUT" --max_retries "$MAX_RETRIES"
+PYENV_VERSION="$PYTHON_VERSION" pyenv exec python examples/download_state.py \
+  --state "$STATE" \
+  --polygon "$POLYGON" \
+  --folder "$FOLDER" \
+  --tries "$TRIES" \
+  --debug "$DEBUG" \
+  --timeout "$TIMEOUT" \
+  --max_retries "$MAX_RETRIES"
 

--- a/download_state.sh
+++ b/download_state.sh
@@ -20,7 +20,6 @@ if ! pyenv versions --bare | grep -q "^$PYTHON_VERSION$"; then
 fi
 
 # \u1F680 Instala dependências via pyenv
-pyenv install -s "$PYTHON_VERSION"
 PYENV_VERSION="$PYTHON_VERSION" pyenv exec pip install --upgrade pip
 PYENV_VERSION="$PYTHON_VERSION" pyenv exec pip install --editable .[paddle]
 

--- a/entrypoint.api.sh
+++ b/entrypoint.api.sh
@@ -2,13 +2,18 @@
 # entrypoint.api.sh
 set -e
 
-VENV=/opt/venv
-PYTHON=python
+PYTHON_VERSION="3.11.8"
 
-${PYTHON} -m venv $VENV
-source $VENV/bin/activate
+if ! command -v pyenv &> /dev/null; then
+  echo "pyenv não encontrado"
+  exit 1
+fi
 
-pip install --upgrade pip
-pip install fastapi uvicorn httpx Pillow tqdm python-multipart
+pyenv install -s "$PYTHON_VERSION"
+PYENV_VERSION="$PYTHON_VERSION" pyenv exec pip install --upgrade pip
+PYENV_VERSION="$PYTHON_VERSION" pyenv exec \
+  pip install fastapi uvicorn httpx Pillow tqdm python-multipart
 
-exec uvicorn app:app --host 0.0.0.0 --port 8000
+exec PYENV_VERSION="$PYTHON_VERSION" pyenv exec \
+  uvicorn app:app --host 0.0.0.0 --port 8000
+

--- a/entrypoint.download.sh
+++ b/entrypoint.download.sh
@@ -3,14 +3,32 @@
 
 set -e
 
+PYTHON_VERSION="3.11.8"
+
+if ! command -v pyenv &> /dev/null; then
+  echo "pyenv não encontrado"
+  exit 1
+fi
+
+pyenv install -s "$PYTHON_VERSION"
+
 STATE=${STATE:-DF}
 FOLDER=${FOLDER:-data/$STATE}
-mkdir -p "$FOLDER"
 POLYGON=${POLYGON:-APPS}
 TRIES=${TRIES:-25}
 DEBUG=${DEBUG:-False}
 TIMEOUT=${TIMEOUT:-30}
 MAX_RETRIES=${MAX_RETRIES:-5}
-
 mkdir -p "$FOLDER"
+
+PYENV_VERSION="$PYTHON_VERSION" pyenv exec python examples/download_state.py \
+  --state "$STATE" \
+  --polygon "$POLYGON" \
+  --folder "$FOLDER" \
+  --tries "$TRIES" \
+  --debug "$DEBUG" \
+  --timeout "$TIMEOUT" \
+  --max_retries "$MAX_RETRIES"
+
+
 


### PR DESCRIPTION
## Summary
- remove native venv activation and rely on pyenv
- run pip and python commands via `pyenv exec`

## Testing
- `python -m pip install -e .[dev]`
- `make unit-test` *(fails: ImportError: cannot import name 'Paddle')*

------
https://chatgpt.com/codex/tasks/task_e_6866b2bca6b4832fa12d24167fb98784